### PR TITLE
[FIX] 메모 자동 생성 오류

### DIFF
--- a/meme_android/app/src/main/java/com/likewhile/meme/data/local/MemoDBHelper.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/data/local/MemoDBHelper.kt
@@ -16,6 +16,9 @@ class MemoDBHelper(context: Context) :
     SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
     override fun onCreate(db: SQLiteDatabase) {
         db.execSQL(CREATE_TABLE_SQL)
+
+        val memoItem = TextMemoItem(title = "first Memo", content = "hello, world")
+        insertMemo(memoItem, db)
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
@@ -122,7 +125,7 @@ class MemoDBHelper(context: Context) :
         return memoItem
     }
 
-    fun insertMemo(memoItem: MemoItem) {
+    fun insertMemo(memoItem: MemoItem, db: SQLiteDatabase? = null) {
         val values = ContentValues()
         values.put(COLUMN_TITLE, memoItem.title)
         values.put(COLUMN_DATE, DateFormatUtil.dateToString(memoItem.date))
@@ -138,9 +141,11 @@ class MemoDBHelper(context: Context) :
             }
         }
 
-        val db = writableDatabase
-        db.insert(TABLE_NAME, null, values)
-        db.close()
+        val database = db ?: writableDatabase
+        database.insert(TABLE_NAME, null, values)
+        if (db == null) {
+            database.close()
+        }
     }
 
     fun updateMemo(memoItem: MemoItem) {

--- a/meme_android/app/src/main/java/com/likewhile/meme/ui/view/CalendarModeFragment.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/ui/view/CalendarModeFragment.kt
@@ -32,16 +32,19 @@ class CalendarModeFragment : Fragment(), CalendarAdapter.OnMonthChangeListener, 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
 
         binding = FragmentCalendarModeBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         initCalendar()
         initCalendarData()
-
-        return binding.root
     }
 
     private fun initCalendar() {


### PR DESCRIPTION
## Summary
만들지 않은 메모가 캘린더 모드일 때, 존재한다고 화면에 뜨는 문제
point를 클릭해서 상세 조회하려고 하면 앱이 강제 종료됨
```
//item_calendar.xml
  <com.google.android.material.imageview.ShapeableImageView
      android:id="@+id/point"
      android:layout_width="10dp"
      android:layout_height="10dp"
      android:layout_marginTop="8dp"
      android:src="@drawable/ic_launcher_background"
      android:tint="@color/light_blue_100"
      android:visibility="gone"
      app:layout_constraintDimensionRatio="1:1"
      app:layout_constraintEnd_toEndOf="parent"
      app:layout_constraintStart_toStartOf="parent"
      app:layout_constraintTop_toTopOf="parent"
      app:layout_constraintWidth_percent="0.50"
      app:shapeAppearanceOverlay="@style/Circle" />
```
```
//CalendarAdapter.kt
if (!feedList.isNullOrEmpty()) {
    for (feed in feedList!!) {
        if (feed.day == date) {
            Log.d(TAG, "bind: $feed , $date")
            binding.point.visibility = View.VISIBLE
            itemView.setOnClickListener {
                itemClickListener.onClick(itemView, position, feed.day)
            }
        }
    }
} else {
    binding.point.visibility = View.GONE
}
```
달력 모드일 때 위와 같이 기본으로 point가 gone 처리 되어있고, 조회되는 feed.day와 xml에 띄울 달력 형태인 date의 날짜가 같을 때만, visible로 처리되도록 작성되어 있지만, Log.d(TAG, "bind: $feed , $date") 코드 부분쪽으로는 log가 남지않고 visible 처리는 되는 이상한 상황입니다. 
<img width="554" alt="image" src="https://user-images.githubusercontent.com/52189097/231821016-0120dc2c-3e53-4957-8aa8-f0b346ee8028.png">

위의 상황에 대한 이유로 두 가지 정도가 추측이 됩니다.
1. 원래 생각하던 widget 생성을 위한 아래의 코드에서 해당 에러가 발생했을 경우
```
//MemoWidgetProvider.kt
  private fun createNewMemo(context: Context): MemoItem {
      val dbHelper = MemoDBHelper(context)
      val memo = TextMemoItem(
          0L, // ID는 데이터베이스에서 자동으로 생성됩니다.
          "new memo", // 제목
          "", // 내용
          Date(), // 날짜
          false // 고정 여부
      )

      dbHelper.insertMemo(memo)
      val memoItems = dbHelper.selectAllMemos(3)
      return memoItems.last() // 가장 최근에 저장된 메모를 반환합니다.
  }
```
과거 도연님의 휴대폰으로 확인했을 때, 에러를 발생 시키는 메모(에러메모)의 제목이 new Memo으로 확인되었습니다. 따라서 위의 코드가 오류를 유발했을 가능성이 있습니다.
- 캘린더 모드에서 이상하게 생성되는 메모의 조회 되는 날짜를 확인하면 더 자세하게 알 수 있을 것 같으므로 이 PR을 확인할 때, 오류를 발생 시키는 메모의 날짜를 확인하고 댓글로 달아주세요. 현재는 이 메모의 생성 시기가 앱을 다운했을 때와 유사하다고 판단하여 위젯에 대한 코드 부분이 돌아갈 때, 메모가 잘못 만들어지고 있을 수도 있다고 판단했습니다.
2. 2월 달에서 3월 달로 넘어갈 때는 해당 에러 메모가 화면에 보이지 않지만, 4월에서 3월 달로 넘어갈 때는 해당 에러 메모가 화면에 보이는 것은 ViewBinding 문제일 수도 있다고 추측합니다. 하지만 왜 3월 1일만 에러메모가 조회되는지에 대한 이유를 찾을 수 없기 때문에 아닐 가능성이 높습니다.
## Describe your changes
1번에 대한 해결 방법으로, 처음 위젯에 대한 검사를 수행할 때 메모가 존재하고 있다면, 새로운 메모가 생성되지 않을 수 있다고 판단하여 처음 데이터베이스를 만들 때, 첫 메모를 생성하는 기능을 추가
2번에 대한 이유로 UI 작업을 OnCreateView가 아닌 onViewCreated로 수정

## Issue number and link
open #9 