### PR TITLE
[Feat] 리스트 메모 추가

### DIFF
--- a/meme_android/app/src/main/java/com/likewhile/meme/data/model/ListItem.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/data/model/ListItem.kt
@@ -2,5 +2,5 @@ package com.likewhile.meme.data.model
 
 data class ListItem(
     var title: String,
-    val priority: Int
+    var priority: Int
 )

--- a/meme_android/app/src/main/java/com/likewhile/meme/ui/adapter/ListAdapter.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/ui/adapter/ListAdapter.kt
@@ -77,6 +77,7 @@ class ListAdapter(
             ITEM_TYPE_NORMAL -> {
                 val normalViewHolder = holder as ListViewHolder
                 val listItem = listItems[position]
+                listItem.priority = position + 1
                 normalViewHolder.binding.titleTextView.isEnabled = clickable
                 normalViewHolder.binding.titleTextView.setTextColor(Color.BLACK)
                 normalViewHolder.bind(listItem)
@@ -96,6 +97,8 @@ class ListAdapter(
     fun onItemMove(fromPosition: Int, toPosition: Int) {
         Collections.swap(listItems, fromPosition, toPosition)
         notifyItemMoved(fromPosition, toPosition)
+        notifyItemChanged(fromPosition)
+        notifyItemChanged(toPosition)
     }
 
     override fun getItemCount() = listItems.size

--- a/meme_android/app/src/main/java/com/likewhile/meme/ui/adapter/ListAdapter.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/ui/adapter/ListAdapter.kt
@@ -1,14 +1,14 @@
 package com.likewhile.meme.ui.adapter
 
-import android.content.Context
 import android.graphics.Color
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
+import android.view.animation.AnimationUtils
 import androidx.recyclerview.widget.RecyclerView
+import com.likewhile.meme.R
 import com.likewhile.meme.data.model.ListItem
 import com.likewhile.meme.databinding.ItemListAddBinding
 import com.likewhile.meme.databinding.ItemListBinding
@@ -21,14 +21,10 @@ class ListAdapter(
     private val onAddButtonClick: () -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    companion object {
-        const val ITEM_TYPE_NORMAL = 0
-        const val ITEM_TYPE_ADD_BUTTON = 1
-    }
-
     private var clickable: Boolean = true
     private var editable: Boolean = true
     lateinit var recyclerView: RecyclerView
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
             ITEM_TYPE_ADD_BUTTON -> {
@@ -60,6 +56,7 @@ class ListAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        setAnimation(holder.itemView, position)
         when (getItemViewType(position)) {
             ITEM_TYPE_ADD_BUTTON -> {
                 val addButtonHolder = holder as ListAddViewHolder
@@ -67,7 +64,6 @@ class ListAdapter(
                     addButtonHolder.binding.addItemButton.visibility = View.VISIBLE
                     addButtonHolder.binding.addItemButton.setOnClickListener {
                         onAddButtonClick()
-                        addButtonHolder.binding.addItemButton.visibility = View.GONE
                     }
                 } else {
                     addButtonHolder.binding.addItemButton.visibility = View.GONE
@@ -111,14 +107,7 @@ class ListAdapter(
     }
 
 
-    inner class ListAddViewHolder(val binding: ItemListAddBinding) : RecyclerView.ViewHolder(binding.root) {
-        init {
-            binding.addItemButton.setOnClickListener {
-                onAddButtonClick()
-            }
-        }
-    }
-
+    inner class ListAddViewHolder(val binding: ItemListAddBinding) : RecyclerView.ViewHolder(binding.root)
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
@@ -157,5 +146,23 @@ class ListAdapter(
     fun addAll(listItems: List<ListItem>) {
         this.listItems.addAll(listItems)
         notifyDataSetChanged()
+    }
+
+
+    private fun setAnimation(viewToAnimate: View, position: Int) {
+        if (position == listItems.lastIndex - 1) {
+            val animation = AnimationUtils.loadAnimation(viewToAnimate.context, R.anim.item_animation_fall_down)
+            animation.startOffset = ANIMATION_DELAY
+            animation.duration = ANIMATION_DURATION
+            viewToAnimate.startAnimation(animation)
+        }
+    }
+
+
+    companion object {
+        const val ITEM_TYPE_NORMAL = 0
+        const val ITEM_TYPE_ADD_BUTTON = 1
+        private const val ANIMATION_DELAY = 100L
+        private const val ANIMATION_DURATION = 300L
     }
 }

--- a/meme_android/app/src/main/java/com/likewhile/meme/ui/adapter/ListAdapter.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/ui/adapter/ListAdapter.kt
@@ -136,6 +136,7 @@ class ListAdapter(
     fun removeItem(position: Int) {
         listItems.removeAt(position)
         notifyItemRemoved(position)
+        notifyItemRangeChanged(position, listItems.size - position)
     }
 
     fun setItemsClickable(clickable: Boolean) {

--- a/meme_android/app/src/main/java/com/likewhile/meme/ui/view/ListMemoEditActivity.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/ui/view/ListMemoEditActivity.kt
@@ -38,15 +38,17 @@ class ListMemoEditActivity : AppCompatActivity() {
 
     private lateinit var memoViewModel: ListMemoViewModel
     private lateinit var listAdapter: ListAdapter
-    private lateinit var itemTouchHelperCallback:ListItemTouchHelperCallback
+    private lateinit var itemTouchHelperCallback: ListItemTouchHelperCallback
 
     private var isMenuVisible = true
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        memoViewModel = ViewModelProvider(this, ViewModelProvider.AndroidViewModelFactory(application)).get(
-            ListMemoViewModel::class.java)
+        memoViewModel =
+            ViewModelProvider(this, ViewModelProvider.AndroidViewModelFactory(application)).get(
+                ListMemoViewModel::class.java
+            )
 
         initRecyclerView()
         initMemoData()
@@ -112,129 +114,132 @@ class ListMemoEditActivity : AppCompatActivity() {
             val contentList = listAdapter.getItems()
             val isFixed = binding.bottomBtnEdit.checkBoxFix.isChecked
 
-            val listItems = contentList.mapIndexed  { index, item ->
+            val listItems = contentList.filterIndexed { index, item ->
+                listAdapter.getItemViewType(index) == ListAdapter.ITEM_TYPE_NORMAL
+            }.map {
                 ListItem(
-                    priority = index + 1,
-                    title = item.title,
+                    priority = it.priority,
+                    title = it.title,
                 )
             }
 
-            val memoItem = ListMemoItem(
-                id = itemId,
-                title = title,
-                listItems = listItems,
-                date = Date(),
-                isFixed = isFixed,
-            )
+        val memoItem = ListMemoItem(
+            id = itemId,
+            title = title,
+            listItems = listItems,
+            date = Date(),
+            isFixed = isFixed,
+        )
 
-            if (title.isBlank() || contentList.isEmpty())
-                Toast.makeText(this, "제목과 상세내용을 입력해주세요.", Toast.LENGTH_SHORT).show()
-            else {
-                if (itemId != -1L) {
-                    memoViewModel.updateMemo(memoItem)
-                    updateWidget()
-                } else {
-                    memoViewModel.insertMemo(memoItem)
-                }
-                setReadMode()
-                val focusedView = currentFocus
-                focusedView?.clearFocus()
-
-                val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                inputMethodManager.hideSoftInputFromWindow(focusedView?.windowToken, 0)
-
-                Toast.makeText(this, "save", Toast.LENGTH_SHORT).show()
+        if (title.isBlank() || contentList.isEmpty())
+            Toast.makeText(this, "제목과 상세내용을 입력해주세요.", Toast.LENGTH_SHORT).show()
+        else {
+            if (itemId != -1L) {
+                memoViewModel.updateMemo(memoItem)
+                updateWidget()
+            } else {
+                memoViewModel.insertMemo(memoItem)
             }
-        }
-    }
-
-
-    private fun initCancel() {
-        binding.bottomBtnEdit.buttonCancel.setOnClickListener { finish() }
-    }
-
-
-    private fun initMemoData() {
-        if (itemId != -1L) {
-            memoViewModel.setItemId(itemId)
             setReadMode()
-        } else {
+            val focusedView = currentFocus
+            focusedView?.clearFocus()
+
+            val inputMethodManager =
+                getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(focusedView?.windowToken, 0)
+
+            Toast.makeText(this, "save", Toast.LENGTH_SHORT).show()
+        }
+    }
+}
+
+
+private fun initCancel() {
+    binding.bottomBtnEdit.buttonCancel.setOnClickListener { finish() }
+}
+
+
+private fun initMemoData() {
+    if (itemId != -1L) {
+        memoViewModel.setItemId(itemId)
+        setReadMode()
+    } else {
+        setEditMode()
+    }
+
+    memoViewModel.memo.observe(this) { memo ->
+        if (memo != null) {
+            binding.title.editTextTitle.setText(memo.title)
+            binding.bottomBtnEdit.checkBoxFix.isChecked = memo.isFixed
+            listAdapter.clear()
+            listAdapter.addAll(memo.listItems)
+        }
+    }
+}
+
+override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    menuInflater.inflate(R.menu.menu_toolbar, menu)
+    return true
+}
+
+
+override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    when (item.itemId) {
+        android.R.id.home -> {
+            finish()
+            return true
+        }
+        R.id.button_edit_mode -> {
             setEditMode()
+            return true
         }
-
-        memoViewModel.memo.observe(this) { memo ->
-            if (memo != null) {
-                binding.title.editTextTitle.setText(memo.title)
-                binding.bottomBtnEdit.checkBoxFix.isChecked = memo.isFixed
-                listAdapter.clear()
-                listAdapter.addAll(memo.listItems)
-            }
-        }
+        else -> return super.onOptionsItemSelected(item)
     }
-
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.menu_toolbar, menu)
-        return true
-    }
+}
 
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
-            android.R.id.home -> {
-                finish()
-                return true
-            }
-            R.id.button_edit_mode -> {
-                setEditMode()
-                return true
-            }
-            else -> return super.onOptionsItemSelected(item)
-        }
-    }
+override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+    val menuItem = menu.findItem(R.id.button_edit_mode)
+    menuItem.isVisible = isMenuVisible
+    return super.onPrepareOptionsMenu(menu)
+}
 
 
-    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        val menuItem = menu.findItem(R.id.button_edit_mode)
-        menuItem.isVisible = isMenuVisible
-        return super.onPrepareOptionsMenu(menu)
-    }
+override fun onDestroy() {
+    super.onDestroy()
+    memoViewModel.closeDB()
+}
 
 
-    override fun onDestroy() {
-        super.onDestroy()
-        memoViewModel.closeDB()
-    }
+private fun setReadMode() {
+    binding.title.editTextTitle.isEnabled = false
+    binding.title.editTextTitle.alpha = 0.8f
+    binding.title.editTextTitle.setTextColor(Color.BLACK)
+    binding.bottomBtnEdit.checkBoxFix.isEnabled = false
+    binding.bottomBtnEdit.checkBoxFix.setTextColor(Color.BLACK)
+    binding.bottomBtnEdit.buttonSave.visibility = View.GONE
+    binding.bottomBtnEdit.buttonCancel.visibility = View.GONE
+    listAdapter.setItemsClickable(false)
+    listAdapter.setItemEditable(false)
+    itemTouchHelperCallback.setEnabled(false)
+
+    // 메뉴를 무효화하여 onPrepareOptionsMenu()를 다시 호출
+    isMenuVisible = true
+    invalidateOptionsMenu()
+}
 
 
-    private fun setReadMode() {
-        binding.title.editTextTitle.isEnabled = false
-        binding.title.editTextTitle.alpha = 0.8f
-        binding.title.editTextTitle.setTextColor(Color.BLACK)
-        binding.bottomBtnEdit.checkBoxFix.isEnabled = false
-        binding.bottomBtnEdit.checkBoxFix.setTextColor(Color.BLACK)
-        binding.bottomBtnEdit.buttonSave.visibility = View.GONE
-        binding.bottomBtnEdit.buttonCancel.visibility = View.GONE
-        listAdapter.setItemsClickable(false)
-        listAdapter.setItemEditable(false)
-        itemTouchHelperCallback.setEnabled(false)
+private fun setEditMode() {
+    binding.title.editTextTitle.isEnabled = true
+    binding.bottomBtnEdit.checkBoxFix.isEnabled = true
+    binding.bottomBtnEdit.buttonSave.visibility = View.VISIBLE
+    binding.bottomBtnEdit.buttonCancel.visibility = View.VISIBLE
+    listAdapter.setItemsClickable(true)
+    listAdapter.setItemEditable(true)
+    itemTouchHelperCallback.setEnabled(true)
 
-        // 메뉴를 무효화하여 onPrepareOptionsMenu()를 다시 호출
-        isMenuVisible = true
-        invalidateOptionsMenu()
-    }
-
-
-    private fun setEditMode() {
-        binding.title.editTextTitle.isEnabled = true
-        binding.bottomBtnEdit.checkBoxFix.isEnabled = true
-        binding.bottomBtnEdit.buttonSave.visibility = View.VISIBLE
-        binding.bottomBtnEdit.buttonCancel.visibility = View.VISIBLE
-        listAdapter.setItemsClickable(true)
-        listAdapter.setItemEditable(true)
-        itemTouchHelperCallback.setEnabled(true)
-
-        // 메뉴를 무효화하여 onPrepareOptionsMenu()를 다시 호출
-        isMenuVisible = false
-        invalidateOptionsMenu()
-    }
+    // 메뉴를 무효화하여 onPrepareOptionsMenu()를 다시 호출
+    isMenuVisible = false
+    invalidateOptionsMenu()
+}
 }

--- a/meme_android/app/src/main/java/com/likewhile/meme/ui/view/ListMemoEditActivity.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/ui/view/ListMemoEditActivity.kt
@@ -79,10 +79,10 @@ class ListMemoEditActivity : AppCompatActivity() {
         }
 
         listAdapter = ListAdapter(initialList) {
-            val newItem = ListItem(priority = listAdapter.itemCount + 1, title = "")
-            initialList.add(newItem)
-            listAdapter.notifyItemInserted(listAdapter.itemCount - 1)
-            binding.contentRecyclerview.scrollToPosition(listAdapter.itemCount - 1)
+            val newItem = ListItem(priority = listAdapter.itemCount, title = "")
+            initialList.add(initialList.lastIndex, newItem)
+            listAdapter.notifyItemInserted(initialList.lastIndex)
+            binding.contentRecyclerview.scrollToPosition(initialList.lastIndex)
         }
         binding.contentRecyclerview.adapter = listAdapter
         binding.contentRecyclerview.layoutManager = LinearLayoutManager(this)

--- a/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
@@ -14,7 +14,7 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder
     ): Int {
-        return if (enabled) {
+        return if (enabled && viewHolder.itemViewType == ListAdapter.ITEM_TYPE_NORMAL) {
             val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
             val swipeFlags = ItemTouchHelper.END
             makeMovementFlags(dragFlags, swipeFlags)
@@ -27,6 +27,9 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
+        if (target.itemViewType == ListAdapter.ITEM_TYPE_ADD_BUTTON || viewHolder.itemViewType == ListAdapter.ITEM_TYPE_ADD_BUTTON) {
+            return false
+        }
         adapter.onItemMove(viewHolder.layoutPosition, target.layoutPosition)
         viewHolder.itemView.setBackgroundColor(ContextCompat.getColor(viewHolder.itemView.context, R.color.teal_700))
         return true

--- a/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
@@ -14,7 +14,7 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder
     ): Int {
-        return if (enabled && viewHolder.itemViewType == ListAdapter.ITEM_TYPE_NORMAL) {
+        return if (enabled) {
             val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
             val swipeFlags = ItemTouchHelper.END
             makeMovementFlags(dragFlags, swipeFlags)
@@ -27,9 +27,6 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
-        if (target.itemViewType == ListAdapter.ITEM_TYPE_ADD_BUTTON || viewHolder.itemViewType == ListAdapter.ITEM_TYPE_ADD_BUTTON) {
-            return false
-        }
         adapter.onItemMove(viewHolder.layoutPosition, target.layoutPosition)
         viewHolder.itemView.setBackgroundColor(ContextCompat.getColor(viewHolder.itemView.context, R.color.teal_700))
         return true

--- a/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
@@ -1,7 +1,11 @@
 package com.likewhile.meme.util
 
+import android.annotation.SuppressLint
+import android.graphics.Color
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
+import com.likewhile.meme.R
 import com.likewhile.meme.ui.adapter.ListAdapter
 
 class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchHelper.Callback() {
@@ -18,18 +22,24 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
             makeMovementFlags(0, 0)
         }
     }
-
     override fun onMove(
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
-        adapter.onItemMove(viewHolder.adapterPosition, target.adapterPosition)
+        adapter.onItemMove(viewHolder.layoutPosition, target.layoutPosition)
+        viewHolder.itemView.setBackgroundColor(ContextCompat.getColor(viewHolder.itemView.context, R.color.teal_700))
         return true
     }
 
+
+    override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
+        super.onSelectedChanged(viewHolder, actionState)
+        viewHolder?.itemView?.setBackgroundColor(ContextCompat.getColor(viewHolder.itemView.context, R.color.teal_700))
+    }
+
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-        val position = viewHolder.adapterPosition
+        val position = viewHolder.layoutPosition
         adapter.removeItem(position)
     }
 
@@ -39,6 +49,12 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
 
     override fun isItemViewSwipeEnabled(): Boolean {
         return true
+    }
+
+
+    override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+        super.clearView(recyclerView, viewHolder)
+        viewHolder.itemView.setBackgroundColor(Color.WHITE)
     }
 
     fun setEnabled(enabled: Boolean) {

--- a/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
@@ -14,7 +14,7 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder
     ): Int {
-        return if (enabled) {
+        return if (enabled && viewHolder.itemViewType == ListAdapter.ITEM_TYPE_NORMAL) {
             val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
             val swipeFlags = ItemTouchHelper.END
             makeMovementFlags(dragFlags, swipeFlags)
@@ -27,6 +27,9 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
+        if(target.itemViewType == ListAdapter.ITEM_TYPE_ADD_BUTTON || viewHolder.itemViewType == ListAdapter.ITEM_TYPE_ADD_BUTTON) {
+            return false
+        }
         adapter.onItemMove(viewHolder.layoutPosition, target.layoutPosition)
         viewHolder.itemView.setBackgroundColor(ContextCompat.getColor(viewHolder.itemView.context, R.color.teal_700))
         return true

--- a/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
+++ b/meme_android/app/src/main/java/com/likewhile/meme/util/ListItemTouchHelperCallback.kt
@@ -16,7 +16,7 @@ class ListItemTouchHelperCallback(private val adapter: ListAdapter) : ItemTouchH
     ): Int {
         return if (enabled) {
             val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
-            val swipeFlags = ItemTouchHelper.START or ItemTouchHelper.END
+            val swipeFlags = ItemTouchHelper.END
             makeMovementFlags(dragFlags, swipeFlags)
         } else {
             makeMovementFlags(0, 0)

--- a/meme_android/app/src/main/res/anim/item_animation_fall_down.xml
+++ b/meme_android/app/src/main/res/anim/item_animation_fall_down.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromYDelta="-50%"
+        android:toYDelta="0%"
+        android:duration="@android:integer/config_mediumAnimTime" />
+    <alpha
+        android:fromAlpha="0"
+        android:toAlpha="1"
+        android:duration="@android:integer/config_mediumAnimTime" />
+</set>

--- a/meme_android/app/src/main/res/layout/activity_memo_list_edit.xml
+++ b/meme_android/app/src/main/res/layout/activity_memo_list_edit.xml
@@ -26,30 +26,30 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
+            android:layout_weight="1"
             android:layout_marginStart="10dp"
             android:layout_marginTop="5dp"
             android:layout_marginEnd="10dp"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
             <include
                 android:id="@+id/title"
                 layout="@layout/memo_title"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 app:layout_constraintEnd_toEndOf="@+id/toolbar"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/toolbar" />
-        </LinearLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/content_recyclerview"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            tools:itemCount="5"
-            tools:listitem="@layout/item_list"/>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/content_recyclerview"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/purple_200"
+                tools:itemCount="5"
+                tools:listitem="@layout/item_list"/>
+        </LinearLayout>
 
         <include
             android:id="@+id/bottom_btn_edit"

--- a/meme_android/app/src/main/res/layout/activity_memo_list_edit.xml
+++ b/meme_android/app/src/main/res/layout/activity_memo_list_edit.xml
@@ -45,8 +45,7 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/content_recyclerview"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/purple_200"
+                android:layout_height="match_parent"
                 tools:itemCount="5"
                 tools:listitem="@layout/item_list"/>
         </LinearLayout>

--- a/meme_android/app/src/main/res/layout/item_list.xml
+++ b/meme_android/app/src/main/res/layout/item_list.xml
@@ -12,7 +12,8 @@
         android:id="@+id/list_item_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:background="@color/white">
 
         <TextView
             android:id="@+id/priorityTextView"

--- a/meme_android/app/src/main/res/layout/item_list.xml
+++ b/meme_android/app/src/main/res/layout/item_list.xml
@@ -35,6 +35,7 @@
             android:layout_height="50dp"
             android:layout_marginEnd="10dp"
             android:layout_weight="1"
+            android:inputType="text"
             android:maxLength="25"
             android:maxLines="1"
             android:maxWidth="400dp"

--- a/meme_android/app/src/main/res/layout/item_list_add.xml
+++ b/meme_android/app/src/main/res/layout/item_list_add.xml
@@ -2,7 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@color/white">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/add_item_button"

--- a/meme_android/app/src/main/res/values/colors.xml
+++ b/meme_android/app/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
     <color name="purple_500">#8D7B68</color>
     <color name="purple_700">#8D7B68</color>
     <color name="teal_200">#C8B6A6</color>
-    <color name="teal_700">#F1DEC9</color>
+    <color name="teal_700">#D2C6B8</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="grey">#808080</color>


### PR DESCRIPTION
## Summary
메모의 종류 중 하나인 숫자로 순서가 매겨진 리스트 메모 추가

## Describe your changes
아이템의 순서가 바뀔 때, 매겨진 숫자는 변하지 않던 오류 수정
리스트 개수가 하나 더 나오던 오류 수정
enter를 눌렀을 때, 기능하지 않도록 수정
아이템이 삭제 되었을 때, 해당 아이템보다 아래의 아이템들은 매겨진 숫자를 리프레쉬하도록 변경
스와이프 삭제를 오른쪽으로만 가능하도록 변경
아이템의 상태가 변경되는 시기일 때, 어떤 아이템인지 색 변화
리스트가 추가될 때, 추가되는 애니매이션 기능 추가
리스트를 추가하는 버튼이 리스트 아이템들과 섞이지 않도록 처리

## Issue number and link
close #11 